### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/ljh/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/ljh/projectboard/domain/UserAccount.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/ljh/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/ljh/projectboard/repository/JpaRepositoryTest.java
@@ -46,7 +46,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine(){
         // given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("admin", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newAdmin", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // when


### PR DESCRIPTION
회원 계정의 `user_id`에 UK 적용 완료.

This closes #21