### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,10 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
-    username: root
-    password:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://localhost:5432/board
+    username: admin
+    password: 1234
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #51 